### PR TITLE
Trust IV Relationship check for URN

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -44,8 +44,10 @@ class AppConfig @Inject()(config: Configuration) {
 
   lazy val relationshipName: String =
     config.get[String]("microservice.services.self.relationship-establishment.name")
-  lazy val relationshipIdentifier: String =
-    config.get[String]("microservice.services.self.relationship-establishment.identifier")
+  lazy val taxableRelationshipIdentifier: String =
+    config.get[String]("microservice.services.self.relationship-establishment.taxable.identifier")
+  lazy val nonTaxableRelationshipIdentifier: String =
+    config.get[String]("microservice.services.self.relationship-establishment.nonTaxable.identifier")
 
   lazy val enrolmentStoreProxyUrl: String = config.get[Service]("microservice.services.enrolment-store-proxy").baseUrl
 

--- a/app/services/TrustsIV.scala
+++ b/app/services/TrustsIV.scala
@@ -29,8 +29,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class TrustsIV @Inject()(trustsAuth: TrustsAuthorisedFunctions) extends Logging {
 
   def authenticate[A](identifier: TrustIdentifier,
-                      onIVRelationshipExisting: Future[TrustAuthResponse],
-                      onIVRelationshipNotExisting: Future[TrustAuthResponse]
+                      onIVRelationshipExisting: => Future[TrustAuthResponse],
+                      onIVRelationshipNotExisting: => Future[TrustAuthResponse]
                      )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustAuthResponse] = {
 
     val relationship = identifier match {

--- a/app/services/TrustsIV.scala
+++ b/app/services/TrustsIV.scala
@@ -18,7 +18,7 @@ package services
 
 import com.google.inject.Inject
 import controllers.actions.TrustsAuthorisedFunctions
-import models.TrustAuthResponse
+import models.{TrustAuthResponse, TrustIdentifier, URN, UTR}
 import play.api.Logging
 import uk.gov.hmrc.auth.core.{BusinessKey, FailedRelationship, Relationship}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -28,19 +28,23 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class TrustsIV @Inject()(trustsAuth: TrustsAuthorisedFunctions) extends Logging {
 
-  def authenticate[A](utr: String,
+  def authenticate[A](identifier: TrustIdentifier,
                       onIVRelationshipExisting: Future[TrustAuthResponse],
                       onIVRelationshipNotExisting: Future[TrustAuthResponse]
                      )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustAuthResponse] = {
 
-    val trustIVRelationship =
-      Relationship(trustsAuth.config.relationshipName, Set(BusinessKey(trustsAuth.config.relationshipIdentifier, utr)))
+    val relationship = identifier match {
+      case UTR(utr) =>
+        Relationship(trustsAuth.config.relationshipName, Set(BusinessKey(trustsAuth.config.taxableRelationshipIdentifier, utr)))
+      case URN(urn) =>
+        Relationship(trustsAuth.config.relationshipName, Set(BusinessKey(trustsAuth.config.nonTaxableRelationshipIdentifier, urn)))
+    }
 
-    trustsAuth.authorised(trustIVRelationship) {
+    trustsAuth.authorised(relationship) {
       onIVRelationshipExisting
     } recoverWith {
       case FailedRelationship(msg) =>
-        logger.info(s"[IdentifyForPlayback][Session ID: ${Session.id(hc)}][UTR: $utr]" +
+        logger.info(s"[IdentifyForPlayback][Session ID: ${Session.id(hc)}][UTR/URN: $identifier]" +
           s" Relationship does not exist in Trust IV for user due to $msg")
         onIVRelationshipNotExisting
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -103,7 +103,8 @@ microservice {
     self {
       relationship-establishment {
         name = "Trusts"
-        identifier = "utr"
+        taxable.identifier = "utr"
+        nonTaxable.identifier = "urn"
       }
     }
     # 9595 is enrolment-store-stub for stubbing out enrolment-store-proxy ES0 calls, replaced in QA and Prod

--- a/test/controllers/TrustAuthControllerSpec.scala
+++ b/test/controllers/TrustAuthControllerSpec.scala
@@ -20,7 +20,7 @@ import config.AppConfig
 import connectors.EnrolmentStoreConnector
 import controllers.actions.TrustsAuthorisedFunctions
 import models.EnrolmentStoreResponse.{AlreadyClaimed, NotClaimed, ServerError}
-import models.{TrustAuthAgentAllowed, TrustAuthAllowed, TrustAuthDenied, TrustAuthResponse, URN, UTR}
+import models._
 import org.mockito.Matchers.{any, eq => mEq}
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
@@ -61,34 +61,225 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
       .overrides(bind[EnrolmentStoreConnector].toInstance(mockEnrolmentStoreConnector))
 
   "authorisedForIdentifier with a utr" when {
+
     val utr = "0987654321"
+
     val utrTrustsEnrolment = Enrolment("HMRC-TERS-ORG", List(EnrolmentIdentifier("SAUTR", utr)), "Activated", None)
-    val utrEnrolments = Enrolments(Set(
-      agentEnrolment,
-      utrTrustsEnrolment
-    ))
-    "invoking the TrustAuthController" when {
 
-      "authenticating an agent" when {
+    val utrEnrolments = Enrolments(Set(agentEnrolment, utrTrustsEnrolment))
 
-        "trust is claimed and agent is authorised" must {
+    "authenticating an agent" when {
+
+      "an Agent user hasn't enrolled an Agent Services Account" must {
+
+        "redirect the user to the create agent services page" in {
+
+          val noEnrollment = Enrolments(Set())
+
+          val app = applicationBuilder().build()
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, noEnrollment))
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.agentAuthorised().url)
+          val result = route(app, request).value
+
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthDenied(appConfig.createAgentServicesAccountUrl)
+        }
+      }
+
+      "an agent user has correct enrolled in Agent Services Account" must {
+
+        "allow authentication" in {
+          val agentEnrolments = Enrolments(Set(agentEnrolment))
+
+          val app = applicationBuilder().build()
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, agentEnrolments))
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.agentAuthorised().url)
+          val result = route(app, request).value
+
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthAgentAllowed("SomeARN")
+        }
+      }
+
+      "trust is claimed and agent is authorised" must {
+
+        "return authorised for a UTR" in {
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, utrEnrolments))
+
+          val predicatedMatcher = mEq(
+            Enrolment("HMRC-TERS-ORG")
+              .withIdentifier("SAUTR", utr)
+              .withDelegatedAuthRule("trust-auth")
+          )
+
+          when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
+            .thenReturn(Future.successful(()))
+
+          when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
+            .thenReturn(Future.successful(AlreadyClaimed))
+
+          val app = applicationBuilder().build()
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
+
+          val result = route(app, request).value
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthAllowed()
+        }
+      }
+
+      "trust has not been claimed by a trustee" must {
+
+        "redirect to trust not claimed page" in {
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, utrEnrolments))
+
+          when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any[HeaderCarrier], any[ExecutionContext]))
+            .thenReturn(Future.successful(NotClaimed))
+
+          val app = applicationBuilder().build()
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
+
+          val result = route(app, request).value
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthDenied(appConfig.trustNotClaimedUrl)
+        }
+      }
+
+      "agent has not been authorised for any trusts" must {
+
+        "redirect to agent not authorised" in {
+
+          val enrolments = Enrolments(Set(agentEnrolment))
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, enrolments))
+
+          val predicatedMatcher = mEq(
+            Enrolment("HMRC-TERS-ORG")
+              .withIdentifier("SAUTR", utr)
+              .withDelegatedAuthRule("trust-auth")
+          )
+
+          when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
+            .thenReturn(Future.failed(InsufficientEnrolments()))
+
+          when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
+            .thenReturn(Future.successful(AlreadyClaimed))
+
+          val app = applicationBuilder().build()
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
+
+          val result = route(app, request).value
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthDenied(appConfig.agentNotAuthorisedUrl)
+        }
+      }
+
+      "an agent that has a trusts enrolment without matching submitted utr" must {
+
+        "redirect to agent not authorised" in {
+
+          val enrolments = Enrolments(Set(
+            agentEnrolment,
+            Enrolment("HMRC-TERS-ORG", List(EnrolmentIdentifier("SAUTR", "1234567890")), "Activated", None)
+          ))
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, enrolments))
+
+          val predicatedMatcher = mEq(
+            Enrolment("HMRC-TERS-ORG")
+              .withIdentifier("SAUTR", utr)
+              .withDelegatedAuthRule("trust-auth")
+          )
+
+          when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
+            .thenReturn(Future.failed(InsufficientEnrolments()))
+
+
+          when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
+            .thenReturn(Future.successful(AlreadyClaimed))
+
+          val app = applicationBuilder().build()
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
+
+          val result = route(app, request).value
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthDenied(appConfig.agentNotAuthorisedUrl)
+        }
+      }
+
+    }
+
+    "authenticating an organisation user" when {
+
+      "organisation user has an enrolment for the trust" when {
+
+        "relationship does not exist in Trust IV" must {
+
+          "redirect to trust IV for a non claiming check" in {
+
+            val enrolments = Enrolments(Set(utrTrustsEnrolment))
+
+            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
+
+            val expectedRelationship = Relationship("Trusts", Set(BusinessKey("utr", utr)))
+
+            when(mockAuthConnector.authorise(mEq(expectedRelationship), mEq(EmptyRetrieval))(any(), any()))
+              .thenReturn(Future.failed(FailedRelationship()))
+
+            val app = applicationBuilder().build()
+
+            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
+
+            val result = route(app, request).value
+            status(result) mustBe OK
+
+            val response = contentAsJson(result).as[TrustAuthDenied]
+            response.redirectUrl must include("/maintain-this-trust")
+          }
+
+        }
+
+        "relationship does exist in Trust IV" must {
 
           "return OK" in {
 
+            val enrolments = Enrolments(Set(utrTrustsEnrolment))
+
             when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-              .thenReturn(authRetrievals(AffinityGroup.Agent, utrEnrolments))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
 
-            val predicatedMatcher = mEq(
-              Enrolment("HMRC-TERS-ORG")
-                .withIdentifier("SAUTR", utr)
-                .withDelegatedAuthRule("trust-auth")
-            )
+            val expectedRelationship = Relationship("Trusts", Set(BusinessKey("utr", utr)))
 
-            when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
+            when(mockAuthConnector.authorise(mEq(expectedRelationship), mEq(EmptyRetrieval))(any(), any()))
               .thenReturn(Future.successful(()))
-
-            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
-              .thenReturn(Future.successful(AlreadyClaimed))
 
             val app = applicationBuilder().build()
 
@@ -101,15 +292,64 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
             response mustBe TrustAuthAllowed()
           }
         }
+      }
 
-        "trust has not been claimed by a trustee" must {
+      "organisation user has no enrolment for the trust" when {
 
-          "redirect to trust not claimed page" in  {
+        "unable to determine if the UTR belongs to a different org account" must {
+
+          "redirect to tech difficulties" in {
+            val enrolments = Enrolments(Set())
 
             when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-              .thenReturn(authRetrievals(AffinityGroup.Agent, utrEnrolments))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
 
-            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any[HeaderCarrier], any[ExecutionContext]))
+            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
+              .thenReturn(Future.successful(ServerError))
+
+            val app = applicationBuilder().build()
+
+            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
+
+            val result = route(app, request).value
+            status(result) mustBe INTERNAL_SERVER_ERROR
+          }
+        }
+
+        "utr is already claimed by a different org account" must {
+
+          "redirect to already claimed" in {
+
+            val enrolments = Enrolments(Set())
+
+            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
+
+            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
+              .thenReturn(Future.successful(AlreadyClaimed))
+
+            val app = applicationBuilder().build()
+
+            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
+
+            val result = route(app, request).value
+            status(result) mustBe OK
+
+            val response = contentAsJson(result).as[TrustAuthResponse]
+            response mustBe TrustAuthDenied(appConfig.alreadyClaimedUrl)
+          }
+        }
+
+        "utr is not already claimed by an org account" must {
+
+          "redirect to claim a trust" in {
+
+            val enrolments = Enrolments(Set())
+
+            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
+
+            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
               .thenReturn(Future.successful(NotClaimed))
 
             val app = applicationBuilder().build()
@@ -119,205 +359,8 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
             val result = route(app, request).value
             status(result) mustBe OK
 
-            val response = contentAsJson(result).as[TrustAuthResponse]
-            response mustBe TrustAuthDenied(appConfig.trustNotClaimedUrl)
-          }
-        }
-
-        "agent has not been authorised for any trusts" must {
-
-          "redirect to agent not authorised" in {
-
-            val enrolments = Enrolments(Set(agentEnrolment))
-
-            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-              .thenReturn(authRetrievals(AffinityGroup.Agent, enrolments))
-
-            val predicatedMatcher = mEq(
-              Enrolment("HMRC-TERS-ORG")
-                .withIdentifier("SAUTR", utr)
-                .withDelegatedAuthRule("trust-auth")
-            )
-
-            when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
-              .thenReturn(Future.failed(InsufficientEnrolments()))
-
-            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
-              .thenReturn(Future.successful(AlreadyClaimed))
-
-            val app = applicationBuilder().build()
-
-            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
-
-            val result = route(app, request).value
-            status(result) mustBe OK
-
-            val response = contentAsJson(result).as[TrustAuthResponse]
-            response mustBe TrustAuthDenied(appConfig.agentNotAuthorisedUrl)
-          }
-        }
-
-        "an agent that has a trusts enrolment without matching submitted utr" must {
-
-          "redirect to agent not authorised" in {
-
-            val enrolments = Enrolments(Set(
-              agentEnrolment,
-              Enrolment("HMRC-TERS-ORG", List(EnrolmentIdentifier("SAUTR", "1234567890")), "Activated", None)
-            ))
-
-            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-              .thenReturn(authRetrievals(AffinityGroup.Agent, enrolments))
-
-            val predicatedMatcher = mEq(
-              Enrolment("HMRC-TERS-ORG")
-                .withIdentifier("SAUTR", utr)
-                .withDelegatedAuthRule("trust-auth")
-            )
-
-            when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
-              .thenReturn(Future.failed(InsufficientEnrolments()))
-
-
-            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
-              .thenReturn(Future.successful(AlreadyClaimed))
-
-            val app = applicationBuilder().build()
-
-            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
-
-            val result = route(app, request).value
-            status(result) mustBe OK
-
-            val response = contentAsJson(result).as[TrustAuthResponse]
-            response mustBe TrustAuthDenied(appConfig.agentNotAuthorisedUrl)
-          }
-        }
-
-      }
-
-      "authenticating an organisation user" when {
-
-        "organisation user has an enrolment for the trust" when {
-
-          "relationship does not exist in Trust IV" must {
-
-            "redirect to trust IV for a non claiming check" in {
-
-              val enrolments = Enrolments(Set(utrTrustsEnrolment))
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockAuthConnector.authorise(any[Relationship], mEq(EmptyRetrieval))(any(), any()))
-                .thenReturn(Future.failed(FailedRelationship()))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
-
-              val result = route(app, request).value
-              status(result) mustBe OK
-
-              val response = contentAsJson(result).as[TrustAuthDenied]
-              response.redirectUrl must include("/maintain-this-trust")
-            }
-
-          }
-
-          "relationship does exist in Trust IV" must {
-
-            "return OK" in {
-
-              val enrolments = Enrolments(Set(utrTrustsEnrolment))
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockAuthConnector.authorise(any[Relationship], mEq(EmptyRetrieval))(any(), any()))
-                .thenReturn(Future.successful(()))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
-
-              val result = route(app, request).value
-              status(result) mustBe OK
-
-              val response = contentAsJson(result).as[TrustAuthResponse]
-              response mustBe TrustAuthAllowed()
-            }
-          }
-        }
-
-        "organisation user has no enrolment for the trust" when {
-
-          "unable to determine if the UTR belongs to a different org account" must {
-
-            "redirect to tech difficulties" in {
-              val enrolments = Enrolments(Set())
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
-                .thenReturn(Future.successful(ServerError))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
-
-              val result = route(app, request).value
-              status(result) mustBe INTERNAL_SERVER_ERROR
-            }
-          }
-
-          "utr is already claimed by a different org account" must {
-
-            "redirect to already claimed" in {
-
-              val enrolments = Enrolments(Set())
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
-                .thenReturn(Future.successful(AlreadyClaimed))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
-
-              val result = route(app, request).value
-              status(result) mustBe OK
-
-              val response = contentAsJson(result).as[TrustAuthResponse]
-              response mustBe TrustAuthDenied(appConfig.alreadyClaimedUrl)
-            }
-          }
-
-          "utr is not already claimed by an org account" must {
-
-            "redirect to claim a trust" in {
-
-              val enrolments = Enrolments(Set())
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(UTR(utr)))(any(), any()))
-                .thenReturn(Future.successful(NotClaimed))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(utr).url)
-
-              val result = route(app, request).value
-              status(result) mustBe OK
-
-              val response = contentAsJson(result).as[TrustAuthDenied]
-              response.redirectUrl must include("/claim-a-trust")
-            }
+            val response = contentAsJson(result).as[TrustAuthDenied]
+            response.redirectUrl must include("/claim-a-trust")
           }
         }
       }
@@ -339,7 +382,15 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
       }
     }
 
-    "invoking authenticate" when {
+  }
+
+  "authorisedForIdentifier with a urn" when {
+
+    val urn = "XATRUST12345678"
+    val urnTrustsEnrolment = Enrolment("HMRC-TERSNT-ORG", List(EnrolmentIdentifier("URN", urn)), "Activated", None)
+    val urnEnrolments = Enrolments(Set(agentEnrolment, urnTrustsEnrolment))
+
+    "authenticating an agent user" when {
 
       "an Agent user hasn't enrolled an Agent Services Account" must {
 
@@ -361,7 +412,8 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
           response mustBe TrustAuthDenied(appConfig.createAgentServicesAccountUrl)
         }
       }
-      "Agent user has correct enrolled in Agent Services Account" must {
+
+      "an agent user has correct enrolled in Agent Services Account" must {
         "allow authentication" in {
           val agentEnrolments = Enrolments(Set(agentEnrolment))
 
@@ -379,39 +431,176 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
           response mustBe TrustAuthAgentAllowed("SomeARN")
         }
       }
+
+      "trust is claimed and agent is authorised" must {
+
+        "return OK" in {
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, urnEnrolments))
+
+          val predicatedMatcher = mEq(
+            Enrolment("HMRC-TERSNT-ORG")
+              .withIdentifier("URN", urn)
+              .withDelegatedAuthRule("trust-auth")
+          )
+
+          when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
+            .thenReturn(Future.successful(()))
+
+          when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
+            .thenReturn(Future.successful(AlreadyClaimed))
+
+          val app = applicationBuilder().build()
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
+
+          val result = route(app, request).value
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthAllowed()
+        }
+      }
+
+      "trust has not been claimed by a trustee" must {
+
+        "redirect to trust not claimed page" in {
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, urnEnrolments))
+
+          when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any[HeaderCarrier], any[ExecutionContext]))
+            .thenReturn(Future.successful(NotClaimed))
+
+          val app = applicationBuilder().build()
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
+
+          val result = route(app, request).value
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthDenied(appConfig.trustNotClaimedUrl)
+        }
+      }
+
+      "agent has not been authorised for any trusts" must {
+
+        "redirect to agent not authorised" in {
+
+          val enrolments = Enrolments(Set(agentEnrolment))
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, enrolments))
+
+          val predicatedMatcher = mEq(
+            Enrolment("HMRC-TERSNT-ORG")
+              .withIdentifier("URN", urn)
+              .withDelegatedAuthRule("trust-auth")
+          )
+
+          when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
+            .thenReturn(Future.failed(InsufficientEnrolments()))
+
+          when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
+            .thenReturn(Future.successful(AlreadyClaimed))
+
+          val app = applicationBuilder().build()
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
+
+          val result = route(app, request).value
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthDenied(appConfig.agentNotAuthorisedUrl)
+        }
+      }
+
+      "an agent that has a trusts enrolment without matching submitted urn" must {
+
+        "redirect to agent not authorised" in {
+
+          val enrolments = Enrolments(Set(
+            agentEnrolment,
+            Enrolment("HMRC-TERSNT-ORG", List(EnrolmentIdentifier("URN", "1234567890")), "Activated", None)
+          ))
+
+          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+            .thenReturn(authRetrievals(AffinityGroup.Agent, enrolments))
+
+          val predicatedMatcher = mEq(
+            Enrolment("HMRC-TERSNT-ORG")
+              .withIdentifier("URN", urn)
+              .withDelegatedAuthRule("trust-auth")
+          )
+
+          when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
+            .thenReturn(Future.failed(InsufficientEnrolments()))
+
+
+          when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
+            .thenReturn(Future.successful(AlreadyClaimed))
+
+          val app = applicationBuilder().build()
+
+          val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
+
+          val result = route(app, request).value
+          status(result) mustBe OK
+
+          val response = contentAsJson(result).as[TrustAuthResponse]
+          response mustBe TrustAuthDenied(appConfig.agentNotAuthorisedUrl)
+        }
+      }
+
     }
-  }
 
-  "authorisedForIdentifier with a urn" when {
-    val urn = "XATRUST12345678"
-    val urnTrustsEnrolment = Enrolment("HMRC-TERSNT-ORG", List(EnrolmentIdentifier("URN", urn)), "Activated", None)
-    val urnEnrolments = Enrolments(Set(
-      agentEnrolment,
-      urnTrustsEnrolment
-    ))
+    "authenticating an organisation user" when {
 
-    "invoking the TrustAuthController" when {
+      "organisation user has an enrolment for the trust" when {
 
-      "authenticating an agent" when {
+        "relationship does not exist in Trust IV" must {
 
-        "trust is claimed and agent is authorised" must {
+          "redirect to trust IV for a non claiming check" in {
+
+            val enrolments = Enrolments(Set(urnTrustsEnrolment))
+
+            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
+
+            val expectedRelationship = Relationship("Trusts", Set(BusinessKey("urn", urn)))
+
+            when(mockAuthConnector.authorise(mEq(expectedRelationship), mEq(EmptyRetrieval))(any(), any()))
+              .thenReturn(Future.failed(FailedRelationship()))
+
+            val app = applicationBuilder().build()
+
+            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
+
+            val result = route(app, request).value
+            status(result) mustBe OK
+
+            val response = contentAsJson(result).as[TrustAuthDenied]
+            response.redirectUrl must include("/maintain-this-trust")
+          }
+
+        }
+
+        "relationship does exist in Trust IV" must {
 
           "return OK" in {
 
+            val enrolments = Enrolments(Set(urnTrustsEnrolment))
+
             when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-              .thenReturn(authRetrievals(AffinityGroup.Agent, urnEnrolments))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
 
-            val predicatedMatcher = mEq(
-              Enrolment("HMRC-TERSNT-ORG")
-                .withIdentifier("URN", urn)
-                .withDelegatedAuthRule("trust-auth")
-            )
+            val expectedRelationship = Relationship("Trusts", Set(BusinessKey("urn", urn)))
 
-            when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
+            when(mockAuthConnector.authorise(mEq(expectedRelationship), mEq(EmptyRetrieval))(any(), any()))
               .thenReturn(Future.successful(()))
-
-            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
-              .thenReturn(Future.successful(AlreadyClaimed))
 
             val app = applicationBuilder().build()
 
@@ -424,15 +613,64 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
             response mustBe TrustAuthAllowed()
           }
         }
+      }
 
-        "trust has not been claimed by a trustee" must {
+      "organisation user has no enrolment for the trust" when {
 
-          "redirect to trust not claimed page" in  {
+        "unable to determine if the urn belongs to a different org account" must {
+
+          "redirect to tech difficulties" in {
+            val enrolments = Enrolments(Set())
 
             when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-              .thenReturn(authRetrievals(AffinityGroup.Agent, urnEnrolments))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
 
-            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any[HeaderCarrier], any[ExecutionContext]))
+            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
+              .thenReturn(Future.successful(ServerError))
+
+            val app = applicationBuilder().build()
+
+            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
+
+            val result = route(app, request).value
+            status(result) mustBe INTERNAL_SERVER_ERROR
+          }
+        }
+
+        "urn is already claimed by a different org account" must {
+
+          "redirect to already claimed" in {
+
+            val enrolments = Enrolments(Set())
+
+            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
+
+            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
+              .thenReturn(Future.successful(AlreadyClaimed))
+
+            val app = applicationBuilder().build()
+
+            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
+
+            val result = route(app, request).value
+            status(result) mustBe OK
+
+            val response = contentAsJson(result).as[TrustAuthResponse]
+            response mustBe TrustAuthDenied(appConfig.alreadyClaimedUrl)
+          }
+        }
+
+        "urn is not already claimed by an org account" must {
+
+          "redirect to claim a trust" in {
+
+            val enrolments = Enrolments(Set())
+
+            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
+              .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
+
+            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
               .thenReturn(Future.successful(NotClaimed))
 
             val app = applicationBuilder().build()
@@ -442,205 +680,8 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
             val result = route(app, request).value
             status(result) mustBe OK
 
-            val response = contentAsJson(result).as[TrustAuthResponse]
-            response mustBe TrustAuthDenied(appConfig.trustNotClaimedUrl)
-          }
-        }
-
-        "agent has not been authorised for any trusts" must {
-
-          "redirect to agent not authorised" in {
-
-            val enrolments = Enrolments(Set(agentEnrolment))
-
-            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-              .thenReturn(authRetrievals(AffinityGroup.Agent, enrolments))
-
-            val predicatedMatcher = mEq(
-              Enrolment("HMRC-TERSNT-ORG")
-                .withIdentifier("URN", urn)
-                .withDelegatedAuthRule("trust-auth")
-            )
-
-            when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
-              .thenReturn(Future.failed(InsufficientEnrolments()))
-
-            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
-              .thenReturn(Future.successful(AlreadyClaimed))
-
-            val app = applicationBuilder().build()
-
-            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
-
-            val result = route(app, request).value
-            status(result) mustBe OK
-
-            val response = contentAsJson(result).as[TrustAuthResponse]
-            response mustBe TrustAuthDenied(appConfig.agentNotAuthorisedUrl)
-          }
-        }
-
-        "an agent that has a trusts enrolment without matching submitted urn" must {
-
-          "redirect to agent not authorised" in {
-
-            val enrolments = Enrolments(Set(
-              agentEnrolment,
-              Enrolment("HMRC-TERSNT-ORG", List(EnrolmentIdentifier("URN", "1234567890")), "Activated", None)
-            ))
-
-            when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-              .thenReturn(authRetrievals(AffinityGroup.Agent, enrolments))
-
-            val predicatedMatcher = mEq(
-              Enrolment("HMRC-TERSNT-ORG")
-                .withIdentifier("URN", urn)
-                .withDelegatedAuthRule("trust-auth")
-            )
-
-            when(mockAuthConnector.authorise(predicatedMatcher, mEq(EmptyRetrieval))(any(), any()))
-              .thenReturn(Future.failed(InsufficientEnrolments()))
-
-
-            when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
-              .thenReturn(Future.successful(AlreadyClaimed))
-
-            val app = applicationBuilder().build()
-
-            val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
-
-            val result = route(app, request).value
-            status(result) mustBe OK
-
-            val response = contentAsJson(result).as[TrustAuthResponse]
-            response mustBe TrustAuthDenied(appConfig.agentNotAuthorisedUrl)
-          }
-        }
-
-      }
-
-      "authenticating an organisation user" when {
-
-        "organisation user has an enrolment for the trust" when {
-
-          "relationship does not exist in Trust IV" must {
-
-            "redirect to trust IV for a non claiming check" in {
-
-              val enrolments = Enrolments(Set(urnTrustsEnrolment))
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockAuthConnector.authorise(any[Relationship], mEq(EmptyRetrieval))(any(), any()))
-                .thenReturn(Future.failed(FailedRelationship()))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
-
-              val result = route(app, request).value
-              status(result) mustBe OK
-
-              val response = contentAsJson(result).as[TrustAuthDenied]
-              response.redirectUrl must include("/maintain-this-trust")
-            }
-
-          }
-
-          "relationship does exist in Trust IV" must {
-
-            "return OK" in {
-
-              val enrolments = Enrolments(Set(urnTrustsEnrolment))
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockAuthConnector.authorise(any[Relationship], mEq(EmptyRetrieval))(any(), any()))
-                .thenReturn(Future.successful(()))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
-
-              val result = route(app, request).value
-              status(result) mustBe OK
-
-              val response = contentAsJson(result).as[TrustAuthResponse]
-              response mustBe TrustAuthAllowed()
-            }
-          }
-        }
-
-        "organisation user has no enrolment for the trust" when {
-
-          "unable to determine if the urn belongs to a different org account" must {
-
-            "redirect to tech difficulties" in {
-              val enrolments = Enrolments(Set())
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
-                .thenReturn(Future.successful(ServerError))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
-
-              val result = route(app, request).value
-              status(result) mustBe INTERNAL_SERVER_ERROR
-            }
-          }
-
-          "urn is already claimed by a different org account" must {
-
-            "redirect to already claimed" in {
-
-              val enrolments = Enrolments(Set())
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
-                .thenReturn(Future.successful(AlreadyClaimed))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
-
-              val result = route(app, request).value
-              status(result) mustBe OK
-
-              val response = contentAsJson(result).as[TrustAuthResponse]
-              response mustBe TrustAuthDenied(appConfig.alreadyClaimedUrl)
-            }
-          }
-
-          "urn is not already claimed by an org account" must {
-
-            "redirect to claim a trust" in {
-
-              val enrolments = Enrolments(Set())
-
-              when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-                .thenReturn(authRetrievals(AffinityGroup.Organisation, enrolments))
-
-              when(mockEnrolmentStoreConnector.checkIfAlreadyClaimed(mEq(URN(urn)))(any(), any()))
-                .thenReturn(Future.successful(NotClaimed))
-
-              val app = applicationBuilder().build()
-
-              val request = FakeRequest(GET, controllers.routes.TrustAuthController.authorisedForIdentifier(urn).url)
-
-              val result = route(app, request).value
-              status(result) mustBe OK
-
-              val response = contentAsJson(result).as[TrustAuthDenied]
-              response.redirectUrl must include("/claim-a-trust")
-            }
+            val response = contentAsJson(result).as[TrustAuthDenied]
+            response.redirectUrl must include("/claim-a-trust")
           }
         }
       }
@@ -662,46 +703,5 @@ class TrustAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
       }
     }
 
-    "invoking authenticate" when {
-
-      "an Agent user hasn't enrolled an Agent Services Account" must {
-
-        "redirect the user to the create agent services page" in {
-
-          val noEnrollment = Enrolments(Set())
-
-          val app = applicationBuilder().build()
-
-          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-            .thenReturn(authRetrievals(AffinityGroup.Agent, noEnrollment))
-
-          val request = FakeRequest(GET, controllers.routes.TrustAuthController.agentAuthorised().url)
-          val result = route(app, request).value
-
-          status(result) mustBe OK
-
-          val response = contentAsJson(result).as[TrustAuthResponse]
-          response mustBe TrustAuthDenied(appConfig.createAgentServicesAccountUrl)
-        }
-      }
-      "Agent user has correct enrolled in Agent Services Account" must {
-        "allow authentication" in {
-          val agentEnrolments = Enrolments(Set(agentEnrolment))
-
-          val app = applicationBuilder().build()
-
-          when(mockAuthConnector.authorise(any(), any[Retrieval[RetrievalType]]())(any(), any()))
-            .thenReturn(authRetrievals(AffinityGroup.Agent, agentEnrolments))
-
-          val request = FakeRequest(GET, controllers.routes.TrustAuthController.agentAuthorised().url)
-          val result = route(app, request).value
-
-          status(result) mustBe OK
-
-          val response = contentAsJson(result).as[TrustAuthResponse]
-          response mustBe TrustAuthAgentAllowed("SomeARN")
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
Fix an issue where functions provided as arguments were both evaluated at runtime due to call by value. Implemented `: =>` to arguments to ensure they're call by name, only called when actually invoked; this fixed a duplicate log issue where Has relationship and Does not have relationship logs were both output.
Expanded matchers in spec to ensure the correct values were passed rather than `any()`