### PR TITLE
Enable graphite and metrics locally

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -28,6 +28,7 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 # Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
 # An audit connector must be provided.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.graphite.GraphiteMetricsModule` or create your own.
@@ -66,7 +67,7 @@ metrics {
   durationUnit = SECONDS
   showSamples = true
   jvm = true
-  enabled = false
+  enabled = true
 }
 
 # Microservice specific config
@@ -88,7 +89,7 @@ microservice {
       host = graphite
       port = 2003
       prefix = play.${appName}.
-      enabled = false
+      enabled = true
     }
   }
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -45,6 +45,8 @@
 
     <logger name="com.google.inject" level="INFO"/>
 
+    <logger name="com.codahale.metrics.graphite.GraphiteReporter" level="OFF"/>
+
     <logger name="controllers" level="INFO"/>
     <logger name="services" level="INFO"/>
     <logger name="models" level="INFO"/>


### PR DESCRIPTION
- Supress warning for local logging only around graphite host not being
  found