### PR TITLE
[DP][DDCE-2827] Update scoverage for Jenkins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
Build failed in Jenkins due to scoverage 1.6.0 incompatibility with Scala 2.12.13+
Updating scoverage to 1.9.3 to fix. Tested with [hotfix build](https://build.tax.service.gov.uk/job/Trusts/job/trusts-auth/3/) and it was successful